### PR TITLE
ATO-NONE: Point to IPV template files

### DIFF
--- a/.github/workflows/deploy-stubs.yml
+++ b/.github/workflows/deploy-stubs.yml
@@ -46,7 +46,7 @@ jobs:
           key: orch-sam
 
       - name: SAM build
-        run: sam build --cached --parallel
+        run: sam build --cached --parallel -t ipv-stub-template.yml
 
       - name: Deploy SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.8

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -64,4 +64,4 @@ jobs:
           aws-region: eu-west-2
 
       - name: SAM validate
-        run: sam validate
+        run: sam validate -t ipv-stub-template.yml


### PR DESCRIPTION
Sam build and validation will fail in github actions as we have renames the template files. 

As we have multiple files we will have multiple actions. As a temporary fix the current actions will point to the `IPV template` file and will raise another PR to separate out the workflows to the specific template files and restructure. 