### PR TITLE
BAU: Fix deployments by removing retrieval of private key

### DIFF
--- a/ipv-stub-template.yml
+++ b/ipv-stub-template.yml
@@ -74,9 +74,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub ${Environment}
-          IPV_PRIVATE_ENCRYPTION_KEY: !Sub
-            - "{{resolve:secretsmanager:${SecretArn}:SecretString:IPV_PRIVATE_KEY}}"
-            - SecretArn: arn:aws:secretsmanager:eu-west-2:816047645251:secret:orch-stubs/ipv/private-key-6LNrBi
+          IPV_PRIVATE_ENCRYPTION_KEY: ""
           IPV_PUBLIC_SIGNING_KEY: ""
       Events:
         Get:


### PR DESCRIPTION
Deployments are failing because the private key doesn't exist in AWS. Remove retrieval of key for now to get deployments working again. Testing can still be done locally and in GitHub using committed keys.

Added a ticket to store and retrieve keys in deployed envs:
https://govukverify.atlassian.net/browse/ATO-978