### PR TITLE
ATO-978: Retrieve IPV private encryption key from AWS Secrets Manager

### DIFF
--- a/ipv-stub-template.yml
+++ b/ipv-stub-template.yml
@@ -74,7 +74,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub ${Environment}
-          IPV_PRIVATE_ENCRYPTION_KEY: ""
+          IPV_PRIVATE_ENCRYPTION_KEY: "{{resolve:secretsmanager:/orch-stubs/ipv-private-encryption-key:SecretString}}"
           IPV_PUBLIC_SIGNING_KEY: ""
       Events:
         Get:


### PR DESCRIPTION
New encryption key pair has been added in build (in Secrets Manager and Parameter store) under /orch-stubs/ipv-private-encryption-key and /orch-stubs/ipv-public-encryption-key

Will need to configure Orchestration to return this key from `ConfigurationService::getIPVAuthEncryptionPublicKey` in build

IPV_PUBLIC_SIGNING_KEY isn't currently used (the stub doesn't validate the signature) so leaving blank for now