### PR TITLE
ATO-939: Setup specific workflows and pipelines for stub type

### DIFF
--- a/.github/workflows/deploy-stubs-build-and-promote-auth.yml
+++ b/.github/workflows/deploy-stubs-build-and-promote-auth.yml
@@ -1,4 +1,4 @@
-name: Deploy stubs build and promote
+name: Deploy Stubs Build and Promote Auth
 
 permissions:
   id-token: write
@@ -8,7 +8,8 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
+    paths-ignore:
+      - "**ipv-stub**"
 
 jobs:
   run-checks:
@@ -20,6 +21,7 @@ jobs:
     uses: ./.github/workflows/deploy-stubs.yml
     needs: run-checks
     secrets:
-      GH_ACTIONS_ROLE_ARN: ${{ secrets.ORCH_STUBS_GH_ACTIONS_ROLE_ARN }}
-      ARTIFACT_BUCKET_NAME: ${{ secrets.ORCH_STUBS_ARTIFACT_BUCKET_NAME }}
+      GH_ACTIONS_ROLE_ARN: ${{ secrets.AUTH_STUB_GH_ACTIONS_ROLE_ARN }}
+      ARTIFACT_BUCKET_NAME: ${{ secrets.AUTH_STUB_ARTIFACT_BUCKET_NAME }}
       SIGNING_PROFILE_NAME: ${{ secrets.ORCH_STUBS_SIGNING_PROFILE_NAME }}
+      WORKING_DIRECTORY: build/auth

--- a/.github/workflows/deploy-stubs-build-and-promote-ipv.yml
+++ b/.github/workflows/deploy-stubs-build-and-promote-ipv.yml
@@ -1,0 +1,27 @@
+name: Deploy Stubs Build and Promote IPV
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**auth-stub**"
+
+jobs:
+  run-checks:
+    uses: ./.github/workflows/run-checks.yml
+    secrets:
+      SAM_APP_VALIDATE_ROLE_ARN: ${{ secrets.ORCH_STUBS_SAM_APP_VALIDATE_ROLE_ARN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  deploy:
+    uses: ./.github/workflows/deploy-stubs.yml
+    needs: run-checks
+    secrets:
+      GH_ACTIONS_ROLE_ARN: ${{ secrets.IPV_STUB_GH_ACTIONS_ROLE_ARN }}
+      ARTIFACT_BUCKET_NAME: ${{ secrets.IPV_STUB_ARTIFACT_BUCKET_NAME }}
+      SIGNING_PROFILE_NAME: ${{ secrets.ORCH_STUBS_SIGNING_PROFILE_NAME }}
+      WORKING_DIRECTORY: build/ipv

--- a/.github/workflows/deploy-stubs-dev.yml
+++ b/.github/workflows/deploy-stubs-dev.yml
@@ -1,21 +1,44 @@
-name: Deploy stubs dev
+name: Deploy Stubs Dev
 
 permissions:
   id-token: write
   contents: read
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      auth_deploy:
+        type: boolean
+        default: false
+        description: Auth-Stub
+      ipv_deploy:
+        type: boolean
+        default: false
+        description: IPV-Stub
 
 jobs:
   run-checks:
     uses: ./.github/workflows/run-checks.yml
     secrets:
-      SAM_APP_VALIDATE_ROLE_ARN: ${{ secrets.SAM_APP_VALIDATE_ROLE_ARN }}
+      SAM_APP_VALIDATE_ROLE_ARN: ${{ secrets.DEV_SAM_APP_VALIDATE_ROLE_ARN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  deploy:
+
+  deploy-auth-stub:
+    if: github.event.inputs.auth_deploy == 'true'
     uses: ./.github/workflows/deploy-stubs.yml
     needs: run-checks
     secrets:
-      GH_ACTIONS_ROLE_ARN: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-      ARTIFACT_BUCKET_NAME: ${{ secrets.ARTIFACT_BUCKET_NAME }}
-      SIGNING_PROFILE_NAME: ${{ secrets.SIGNING_PROFILE_NAME }}
+      GH_ACTIONS_ROLE_ARN: ${{ secrets.DEV_AUTH_STUB_GH_ACTIONS_ROLE_ARN }}
+      ARTIFACT_BUCKET_NAME: ${{ secrets.DEV_AUTH_STUB_ARTIFACT_BUCKET_NAME }}
+      SIGNING_PROFILE_NAME: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+      WORKING_DIRECTORY: build/auth
+
+  deploy-ipv-stub:
+    if: github.event.inputs.ipv_deploy == 'true'
+    uses: ./.github/workflows/deploy-stubs.yml
+    needs: run-checks
+    secrets:
+      GH_ACTIONS_ROLE_ARN: ${{ secrets.DEV_IPV_STUB_GH_ACTIONS_ROLE_ARN }}
+      ARTIFACT_BUCKET_NAME: ${{ secrets.DEV_IPV_STUB_ARTIFACT_BUCKET_NAME }}
+      SIGNING_PROFILE_NAME: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+      WORKING_DIRECTORY: build/ipv

--- a/.github/workflows/deploy-stubs.yml
+++ b/.github/workflows/deploy-stubs.yml
@@ -16,6 +16,8 @@ on:
         required: true
       SIGNING_PROFILE_NAME:
         required: true
+      WORKING_DIRECTORY:
+        required: true
 
 jobs:
   deploy:
@@ -44,7 +46,7 @@ jobs:
         with:
           path: .aws-sam/cache
           key: orch-sam
-      
+
       - name: Install dependencies
         run: npm install
 
@@ -56,4 +58,4 @@ jobs:
         with:
           artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-          working-directory: build/ipv
+          working-directory: ${{ secrets.WORKING_DIRECTORY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Pull request
+name: Pull Request
 
 permissions:
   id-token: write
@@ -17,5 +17,5 @@ jobs:
   run-checks:
     uses: ./.github/workflows/run-checks.yml
     secrets:
-      SAM_APP_VALIDATE_ROLE_ARN: ${{ secrets.SAM_APP_VALIDATE_ROLE_ARN }}
+      SAM_APP_VALIDATE_ROLE_ARN: ${{ secrets.DEV_SAM_APP_VALIDATE_ROLE_ARN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -73,5 +73,8 @@ jobs:
           role-to-assume: ${{ secrets.SAM_APP_VALIDATE_ROLE_ARN }}
           aws-region: eu-west-2
 
-      - name: SAM validate
+      - name: SAM validate Auth
+        run: sam validate -t auth-stub-template.yml
+
+      - name: SAM validate IPV
         run: sam validate -t ipv-stub-template.yml

--- a/infrastructure/configuration/build/build-auth-stub-pipeline/parameters.json
+++ b/infrastructure/configuration/build/build-auth-stub-pipeline/parameters.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "SAMStackName",
-    "ParameterValue": "build-orch-stubs-deploy"
+    "ParameterValue": "build-auth-stub-deploy"
   },
   {
     "ParameterKey": "SigningProfileArn",

--- a/infrastructure/configuration/build/build-ipv-stub-pipeline/parameters.json
+++ b/infrastructure/configuration/build/build-ipv-stub-pipeline/parameters.json
@@ -1,0 +1,38 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "OneLoginRepositoryName",
+    "ParameterValue": "orch-stubs"
+  },
+  {
+    "ParameterKey": "IncludePromotion",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "RequireManualApproval",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SAMStackName",
+    "ParameterValue": "build-ipv-stub-deploy"
+  },
+  {
+    "ParameterKey": "SigningProfileArn",
+    "ParameterValue": "arn:aws:signer:eu-west-2:767397776536:/signing-profiles/SigningProfile_Lne9jMArpvlM"
+  },
+  {
+    "ParameterKey": "SigningProfileVersionArn",
+    "ParameterValue": "arn:aws:signer:eu-west-2:767397776536:/signing-profiles/SigningProfile_Lne9jMArpvlM/wnCsZmp8mO"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  }
+]

--- a/infrastructure/configuration/dev/dev-auth-stub-pipeline/parameters.json
+++ b/infrastructure/configuration/dev/dev-auth-stub-pipeline/parameters.json
@@ -1,0 +1,30 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "OneLoginRepositoryName",
+    "ParameterValue": "orch-stubs"
+  },
+  {
+    "ParameterKey": "IncludePromotion",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "RequireManualApproval",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SAMStackName",
+    "ParameterValue": "dev-auth-stub-deploy"
+  },
+  {
+    "ParameterKey": "SigningProfileArn",
+    "ParameterValue": "arn:aws:signer:eu-west-2:816047645251:/signing-profiles/SigningProfile_1SsceuunzEmO"
+  },
+  {
+    "ParameterKey": "SigningProfileVersionArn",
+    "ParameterValue": "arn:aws:signer:eu-west-2:816047645251:/signing-profiles/SigningProfile_1SsceuunzEmO/DPf5VC3w90"
+  }
+]

--- a/infrastructure/configuration/dev/dev-ipv-stub-pipeline/parameters.json
+++ b/infrastructure/configuration/dev/dev-ipv-stub-pipeline/parameters.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "SAMStackName",
-    "ParameterValue": "dev-orch-stubs-deploy"
+    "ParameterValue": "dev-ipv-stub-deploy"
   },
   {
     "ParameterKey": "SigningProfileArn",

--- a/infrastructure/provision_all.sh
+++ b/infrastructure/provision_all.sh
@@ -9,10 +9,15 @@ export AWS_PAGER=""
 ## Provision dependencies
 for dir in configuration/"$AWS_ACCOUNT"/*/; do
   STACK=$(basename "$dir")
-  if [[ $STACK != "$AWS_ACCOUNT-orch-stubs-pipeline" &&  -f configuration/$AWS_ACCOUNT/$STACK/parameters.json ]]; then
+  if [[ $STACK != "$AWS_ACCOUNT-auth-stub-pipeline" && $STACK != "$AWS_ACCOUNT-ipv-stub-pipeline" && -f configuration/$AWS_ACCOUNT/$STACK/parameters.json ]]; then
     $PROVISION_COMMAND "$AWS_ACCOUNT" "$STACK" "$STACK" LATEST &
   fi
 done
 
 ## Provision secure pipelines
-$PROVISION_COMMAND "$AWS_ACCOUNT" "$AWS_ACCOUNT"-orch-stubs-pipeline sam-deploy-pipeline LATEST
+for dir in configuration/"$AWS_ACCOUNT"/*/; do
+  STACK=$(basename "$dir")
+  if [[ $STACK == "$AWS_ACCOUNT-auth-stub-pipeline" || $STACK == "$AWS_ACCOUNT-ipv-stub-pipeline" ]]; then
+    $PROVISION_COMMAND "$AWS_ACCOUNT" "$STACK" sam-deploy-pipeline LATEST
+  fi
+done


### PR DESCRIPTION
## What
Since we have split the template files of the stub types (IPV , Auth) we will need to create a workflow and pipeline per stub.

- They should detect changes and only deployed the modified stubs
- The dev pipeline should allow selecting which stub to deploy

![image](https://github.com/user-attachments/assets/18a534b3-bac1-4ba2-b6d9-8e2f7fa7adb0)
