### PR TITLE
BAU: Fix parsing of token in user-identity handler

### DIFF
--- a/src/main/ipv-stub/ipv-user-identity.ts
+++ b/src/main/ipv-stub/ipv-user-identity.ts
@@ -11,7 +11,6 @@ import {
   successfulJsonResult,
 } from "./helper/result-helper";
 import { getUserIdentityWithToken } from "./service/dynamodb-form-response-service";
-import { IpvTokenResponse } from "./interfaces/ipv-token-response-interface";
 
 export const handler: Handler = async (
   event: APIGatewayProxyEvent
@@ -32,21 +31,17 @@ async function get(
   const accessToken = getTokenOrThrow(event.headers);
 
   try {
-    const userIdentity = await getUserIdentityWithToken(
-      accessToken.access_token
-    );
+    const userIdentity = await getUserIdentityWithToken(accessToken);
     return Promise.resolve(successfulJsonResult(200, userIdentity));
   } catch (error) {
     throw new CodedError(500, `dynamoDb error: ${error}`);
   }
 }
 
-function getTokenOrThrow(
-  headers: APIGatewayProxyEventHeaders
-): IpvTokenResponse {
-  const accessToken = headers["Authorization"] as unknown as IpvTokenResponse;
-  if (!accessToken["access_token"]) {
+function getTokenOrThrow(headers: APIGatewayProxyEventHeaders): string {
+  const accessToken = headers["Authorization"];
+  if (!accessToken) {
     throw new CodedError(400, "Access Token does not exist");
   }
-  return accessToken as unknown as IpvTokenResponse;
+  return accessToken;
 }


### PR DESCRIPTION
Should just be token not whole object