### PR TITLE
BAU: Improve naming of IPV stub user identity table

### DIFF
--- a/ipv-stub-template.yml
+++ b/ipv-stub-template.yml
@@ -51,10 +51,10 @@ Globals:
       - !Ref AWS::NoValue
 
 Resources:
-  DynamoDB:
+  UserIdentityTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub ${Environment}-UserIdentity
+      TableName: !Sub ${Environment}-IpvStub-UserIdentity
       KeySchema:
         - AttributeName: UserIdentityId
           KeyType: HASH
@@ -234,7 +234,7 @@ Resources:
             Action:
               - dynamodb:DescribeTable
               - dynamodb:Get*
-            Resource: !GetAtt DynamoDB.Arn
+            Resource: !GetAtt UserIdentityTable.Arn
 
   UserIdentityTableWriteAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -246,7 +246,7 @@ Resources:
             Effect: Allow
             Action:
               - dynamodb:PutItem
-            Resource: !GetAtt DynamoDB.Arn
+            Resource: !GetAtt UserIdentityTable.Arn
 
   PublicHostedZone:
     Type: AWS::Route53::HostedZone

--- a/src/main/ipv-stub/service/dynamodb-form-response-service.ts
+++ b/src/main/ipv-stub/service/dynamodb-form-response-service.ts
@@ -5,7 +5,7 @@ import { UserIdentity } from "../interfaces/user-identity-interface";
 const client = new DynamoDBClient({});
 const dynamo = DynamoDBDocument.from(client);
 
-const tableName = `${process.env.ENVIRONMENT}-UserIdentity`;
+const tableName = `${process.env.ENVIRONMENT}-IpvStub-UserIdentity`;
 
 export const getUserIdentityWithAuthCode = async (
   authCode: string


### PR DESCRIPTION
- Make it clear that the table is used by IPV stub
- Give it a name in the template to distinguish it from auth code / access token tables