### PR TITLE
ATO-1001: Persist access token

### DIFF
--- a/src/main/ipv-stub/data/ipv-dummy-constants.ts
+++ b/src/main/ipv-stub/data/ipv-dummy-constants.ts
@@ -1,16 +1,9 @@
-import { IpvTokenResponse } from "../interfaces/ipv-token-response-interface";
 import { UserIdentity } from "../interfaces/user-identity-interface";
 
 const env =
   process.env.ENVIRONMENT == "dev" ? "sandpit" : process.env.ENVIRONMENT;
 
 export const AUTH_CODE = "12345";
-
-export const ACCESS_TOKEN: IpvTokenResponse = {
-  access_token: "740e5834-3a29-46b4-9a6f-16142fde533a",
-  token_type: "Bearer",
-  expires_in: 3600,
-};
 
 export const ROOT_URI = `https://oidc.${env}.account.gov.uk`;
 

--- a/src/main/ipv-stub/ipv-user-identity.ts
+++ b/src/main/ipv-stub/ipv-user-identity.ts
@@ -30,13 +30,17 @@ async function get(
 ): Promise<APIGatewayProxyResult> {
   const accessToken = getTokenOrThrow(event.headers);
 
+  let userIdentity;
   try {
     const tokenKey = accessToken.replace("Bearer ", "");
-    const userIdentity = await getUserIdentityWithToken(tokenKey);
-    return Promise.resolve(successfulJsonResult(200, userIdentity));
+    userIdentity = await getUserIdentityWithToken(tokenKey);
   } catch (error) {
     throw new CodedError(500, `dynamoDb error: ${error}`);
   }
+  if (userIdentity == null) {
+    throw new CodedError(500, "Access token not found in DB, or is expired");
+  }
+  return Promise.resolve(successfulJsonResult(200, userIdentity));
 }
 
 function getTokenOrThrow(headers: APIGatewayProxyEventHeaders): string {

--- a/src/main/ipv-stub/service/dynamodb-form-response-service.ts
+++ b/src/main/ipv-stub/service/dynamodb-form-response-service.ts
@@ -26,7 +26,7 @@ export const putUserIdentityWithAuthCode = async (
     Item: {
       UserIdentityId: authCode,
       userIdentity,
-      ttl: getOneDayTimestamp(),
+      ttl: oneHourFromNow(),
     },
   });
 };
@@ -50,7 +50,7 @@ export const putUserIdentityWithToken = async (
     Item: {
       UserIdentityId: token,
       userIdentity,
-      ttl: getOneDayTimestamp(),
+      ttl: oneHourFromNow(),
     },
   });
 };
@@ -72,13 +72,11 @@ export const putStateWithAuthCode = async (authCode: string, state: string) => {
     Item: {
       UserIdentityId: authCode + "-state",
       state,
-      ttl: getOneDayTimestamp(),
+      ttl: oneHourFromNow(),
     },
   });
 };
 
-function getOneDayTimestamp() {
-  const date = new Date();
-  date.setDate(date.getDate() + 1);
-  return Math.floor(date.getTime() / 1000);
+function oneHourFromNow() {
+  return Math.floor(Date.now() / 1000) + 3600;
 }

--- a/src/main/ipv-stub/service/dynamodb-form-response-service.ts
+++ b/src/main/ipv-stub/service/dynamodb-form-response-service.ts
@@ -33,12 +33,17 @@ export const putUserIdentityWithAuthCode = async (
 
 export const getUserIdentityWithToken = async (
   token: string
-): Promise<UserIdentity> => {
+): Promise<UserIdentity | null> => {
   const response = await dynamo.get({
     TableName: tableName,
     Key: { UserIdentityId: token },
   });
-  return response.Item?.userIdentity as unknown as UserIdentity;
+  if (response.Item) {
+    if (response.Item.ttl > Math.floor(Date.now() / 1000)) {
+      return response.Item.userIdentity as unknown as UserIdentity;
+    }
+  }
+  return null;
 };
 
 export const putUserIdentityWithToken = async (


### PR DESCRIPTION
Rather than using a hard-coded access token, instead 

- Generate access token at runtime in ipv-token and save it against user identity. 
- When the token is retrieved in ipv-user-identity, validate the TTL and return null if it is expired. 
- Throw if null is found (either token not in DB or has expired)