### PR TITLE
ATO-871: Fix SAM build race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "build": "sam build --template ipv-stub-template.yml --build-dir build/ipv & sam build --template auth-stub-template.yml --build-dir build/auth & sam build --template spot-stub-template.yml --build-dir build/spot",
+    "build": "(trap 'kill 0' SIGINT; npm run build:auth & npm run build:ipv & npm run build:spot & wait)",
     "build:auth": "sam build --template auth-stub-template.yml --build-dir build/auth",
     "build:ipv": "sam build --template ipv-stub-template.yml --build-dir build/ipv",
+    "build:spot": "sam build --template spot-stub-template.yml --build-dir build/spot",
     "clean": "rm -rf build",
     "clean:auth": "rm -rf build/auth & rm -rf build/build.toml",
     "clean:ipv": "rm -rf build/ipv & rm -rf build/build.toml",


### PR DESCRIPTION
Previously, if the last SAM build happened to finish before the others, npm run build would return before some modules had built. This change continues to build all in parallel, but waits for all three to finish. It also allows the build to be aborted with ctrl+c