### PR TITLE
ATO-1272: Add JWKS endpoint for IPV stub public encryption key

### DIFF
--- a/ipv-stub-template.yml
+++ b/ipv-stub-template.yml
@@ -220,6 +220,34 @@ Resources:
         Sourcemap: true
         Target: node20
 
+  IPVJwksLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Handler: src/main/ipv-stub/ipv-jwks.handler
+      Runtime: nodejs20.x
+      Architectures:
+        - arm64
+      Environment:
+        Variables:
+          ENVIRONMENT: !Sub ${Environment}
+          IPV_AUTHORIZE_PUBLIC_ENCRYPTION_KEY: "{{resolve:ssm:/orch-stubs/ipv-public-encryption-key}}"
+      Events:
+        Get:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /.well-known/jwks.json
+            Method: get
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        EntryPoints:
+          - src/main/ipv-stub/ipv-jwks.ts
+        Minify: true
+        Sourcemap: true
+        Target: node20
+
   IPVUserIdentityLambdaLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/src/main/ipv-stub/helper/env-helper.ts
+++ b/src/main/ipv-stub/helper/env-helper.ts
@@ -3,6 +3,7 @@ import { CodedError } from "./result-helper";
 
 type EnvVar =
   | "IPV_AUTHORIZE_PRIVATE_ENCRYPTION_KEY"
+  | "IPV_AUTHORIZE_PUBLIC_ENCRYPTION_KEY"
   | "ORCH_PUBLIC_SIGNING_KEY"
   | "ENVIRONMENT";
 

--- a/src/main/ipv-stub/helper/key-helpers.ts
+++ b/src/main/ipv-stub/helper/key-helpers.ts
@@ -26,3 +26,16 @@ export const getIpvPrivateKey = async (): Promise<KeyLike> => {
     throw new CodedError(500, "Internal Server Error");
   }
 };
+
+export const getIpvPublicKey = async (): Promise<KeyLike> => {
+  const ipvPublicKeyPem = getEnv("IPV_AUTHORIZE_PUBLIC_ENCRYPTION_KEY");
+  try {
+    return importSPKI(ipvPublicKeyPem, "RSA-OAEP-256");
+  } catch (error) {
+    logger.error(
+      "Failed to parse IPV authorize public encryption key: " +
+        (error as Error).message
+    );
+    throw new CodedError(500, "Internal Server Error");
+  }
+};

--- a/src/main/ipv-stub/ipv-jwks.ts
+++ b/src/main/ipv-stub/ipv-jwks.ts
@@ -1,0 +1,52 @@
+import { exportJWK } from "jose";
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Handler,
+} from "aws-lambda";
+import { getIpvPublicKey } from "./helper/key-helpers";
+import {
+  CodedError,
+  handleErrors,
+  methodNotAllowedError,
+} from "./helper/result-helper";
+import { createHash } from "node:crypto";
+
+export const handler: Handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  return handleErrors(async () => {
+    switch (event.httpMethod) {
+      case "GET":
+        return await get();
+      default:
+        throw methodNotAllowedError(event.httpMethod);
+    }
+  });
+};
+
+async function get(): Promise<APIGatewayProxyResult> {
+  try {
+    const jwk = await exportJWK(await getIpvPublicKey());
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...jwk,
+        kid: jwk.n ? generateKid(jwk.n) : "n/a",
+        use: "enc",
+        alg: "RSA256",
+      }),
+    };
+  } catch (error) {
+    throw new CodedError(
+      500,
+      `Unable to parse IPV public key to JWK. Error: ${error}`
+    );
+  }
+}
+
+const generateKid = (key: string): string => {
+  const hash = createHash("sha256");
+  return hash.update(Buffer.from(key, "ascii")).digest().toString("base64url");
+};


### PR DESCRIPTION
Add JWKS endpoint to serve the IPV stub public encryption key. The `kid` is created from a hash of the key so it is consistent with a specific key.

Sandpit JWKS:
https://ipvstub.oidc.sandpit.account.gov.uk/.well-known/jwks.json