### PR TITLE
ATO-1272: Make JWKS endpoint consistent with production

### DIFF
--- a/src/main/ipv-stub/ipv-jwks.ts
+++ b/src/main/ipv-stub/ipv-jwks.ts
@@ -32,10 +32,14 @@ async function get(): Promise<APIGatewayProxyResult> {
       statusCode: 200,
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        ...jwk,
-        kid: jwk.n ? generateKid(jwk.n) : "n/a",
-        use: "enc",
-        alg: "RSA256",
+        keys: [
+          {
+            ...jwk,
+            kid: jwk.n ? generateKid(jwk.n) : "n/a",
+            use: "enc",
+            alg: "RSA256",
+          },
+        ],
       }),
     };
   } catch (error) {


### PR DESCRIPTION
## What
The production endpoints are in the format:
```json
{
  "keys": [
     {
        "kid":"abcd"
        ..... 
     },
     {
        "kid":"efgh"
        ..... 
     }
   ]
}
```
whereas this stub endpoint was returning 
```json
{
  "kid":"abcd"
  ..... 
}
```

This PR places the existing key in a `keys` array, which more closely matches production JWKS endpoints.