### PR TITLE
ATO-1451: Fix incorrect alg value in JWKS endpoint

### DIFF
--- a/src/main/ipv-stub/ipv-jwks.ts
+++ b/src/main/ipv-stub/ipv-jwks.ts
@@ -37,7 +37,7 @@ async function get(): Promise<APIGatewayProxyResult> {
             ...jwk,
             kid: jwk.n ? generateKid(jwk.n) : "n/a",
             use: "enc",
-            alg: "RSA256",
+            alg: "RS256",
           },
         ],
       }),


### PR DESCRIPTION
The `alg` value of the encryption key in the stubbed IPV JWKS endpoint is not valid. It should be `RS256`. 

We'd like to filter encryption keys based on their algorithm in https://github.com/govuk-one-login/authentication-api/pull/5942. We need to merge this first else the stubbed environments will fail to encrypt IPV auth requests.