### PR TITLE
ATP-1545: add request header helper

### DIFF
--- a/src/main/auth-stub/helpers/request-header-helper.test.ts
+++ b/src/main/auth-stub/helpers/request-header-helper.test.ts
@@ -1,0 +1,27 @@
+import { APIGatewayProxyEventHeaders } from "aws-lambda";
+import { getHeaderValueFromHeaders } from "./request-header-helper";
+
+it("should return header value from header", () => {
+  const headers: APIGatewayProxyEventHeaders = { header: "header value" };
+  const headerValue = getHeaderValueFromHeaders(headers, "header");
+  expect(headerValue).toBe("header value");
+});
+
+test("should return null when header cannot be found in headers", () => {
+  const headers: APIGatewayProxyEventHeaders = { header: "header value" };
+  const headerValue = getHeaderValueFromHeaders(headers, "new-header");
+  expect(headerValue).toBe(null);
+});
+
+describe("matchCase tests", () => {
+  const headers: APIGatewayProxyEventHeaders = { header: "header value" };
+  test("should return header value from header with matchCase set to true", () => {
+    const headerValue = getHeaderValueFromHeaders(headers, "HEADER", true);
+    expect(headerValue).toBe("header value");
+  });
+
+  it("should return null when matchCase set to false", () => {
+    const headerValue = getHeaderValueFromHeaders(headers, "HEADER", false);
+    expect(headerValue).toBe(null);
+  });
+});

--- a/src/main/auth-stub/helpers/request-header-helper.ts
+++ b/src/main/auth-stub/helpers/request-header-helper.ts
@@ -1,0 +1,17 @@
+import { APIGatewayProxyEventHeaders } from "aws-lambda";
+
+export function getHeaderValueFromHeaders(
+  headers: APIGatewayProxyEventHeaders,
+  headerName: string,
+  matchLowerCase = true
+) {
+  if (!headers) {
+    return null;
+  } else if (headers[headerName]) {
+    return headers[headerName];
+  } else if (matchLowerCase && headers[headerName.toLowerCase()]) {
+    return headers[headerName.toLowerCase()];
+  } else {
+    return null;
+  }
+}


### PR DESCRIPTION
Adds a RequestHeaderHelper, matching the validation as in https://github.com/govuk-one-login/authentication-api/blob/main/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java