### PR TITLE
ATO-1545: add user profile interface and service

### DIFF
--- a/src/main/auth-stub/interfaces/user-profile-interface.ts
+++ b/src/main/auth-stub/interfaces/user-profile-interface.ts
@@ -1,0 +1,20 @@
+export interface UserProfile {
+  SubjectID: string;
+  Email: string;
+  EmailVerified: boolean;
+  PhoneNumber: string;
+  PhoneNumberVerified: boolean;
+  Created: string;
+  Updated: string;
+  termsAndConditions: TermsAndConditions;
+  PublicSubjectID: string;
+  LegacySubjectID: string;
+  salt: string;
+  accountVerified: number;
+  testUser: number;
+}
+
+interface TermsAndConditions {
+  version: string;
+  timeStamp: string;
+}

--- a/src/main/auth-stub/services/user-profile-dynamodb-service.test.ts
+++ b/src/main/auth-stub/services/user-profile-dynamodb-service.test.ts
@@ -1,0 +1,13 @@
+import { DUMMY_EMAIL, getUserProfile } from "./user-profile-dynamodb-service";
+
+it("should return the dummy UserProfile if the right email is given", async () => {
+  const userProfile = await getUserProfile(DUMMY_EMAIL);
+  expect(userProfile.Email).toBe(DUMMY_EMAIL);
+  expect(userProfile.SubjectID).toBe("dummy-subject-id");
+});
+
+it("should fail if an invalid email is given", async () => {
+  await expect(getUserProfile("invalid.email@mail.com")).rejects.toThrow(
+    new Error("invalid email")
+  );
+});

--- a/src/main/auth-stub/services/user-profile-dynamodb-service.ts
+++ b/src/main/auth-stub/services/user-profile-dynamodb-service.ts
@@ -1,0 +1,32 @@
+import { UserProfile } from "../interfaces/user-profile-interface";
+
+export const DUMMY_EMAIL = "dummy.email@mail.com";
+
+export const getUserProfile = async (email: string): Promise<UserProfile> => {
+  // TODO: Implement the actual logic to get the user profile from DynamoDB
+  // For now, we return a dummy user profile if the email matches the dummy email
+  // and reject the promise if it doesn't match
+  if (email !== DUMMY_EMAIL) {
+    return Promise.reject(new Error("invalid email"));
+  }
+
+  const dummyUserProfile: UserProfile = {
+    SubjectID: "dummy-subject-id",
+    Email: DUMMY_EMAIL,
+    EmailVerified: true,
+    PhoneNumber: "12345678910",
+    PhoneNumberVerified: true,
+    Created: "2025-04-11T12:00:00",
+    Updated: "2025-04-11T12:00:00",
+    termsAndConditions: {
+      version: "1.0",
+      timeStamp: "2025-04-10T12:00:00",
+    },
+    PublicSubjectID: "public-subject-id",
+    LegacySubjectID: "legacy-subject-id",
+    salt: "salt",
+    accountVerified: 1,
+    testUser: 0,
+  };
+  return Promise.resolve(dummyUserProfile);
+};


### PR DESCRIPTION
Defines the UserProfile interface and the service to get UserProfile.

This is currently just a hardcoded object while we build out the MVP. In the future, we plan to build out this service to connect it to a db, such that we can have lots of UserProfiles and enable them to be defined by using the stub, rather than needing to update in code (though we haven't yet scoped that far)