### PR TITLE
BAU: update ipv int test to use async test setups

### DIFF
--- a/src/test/integration/ipv-stub/ipv-authorize.test.ts
+++ b/src/test/integration/ipv-stub/ipv-authorize.test.ts
@@ -14,9 +14,11 @@ import { Context } from "aws-lambda";
 const STATE = "test-state";
 const AUTH_CODE = "test-auth-code";
 
-beforeEach(resetUserIdentityTable);
-
 describe("IPV Authorize", () => {
+  beforeEach(async () => {
+    await resetUserIdentityTable();
+  });
+
   it("should return 200 for valid GET request and update Dynamo", async () => {
     const response = await handler(
       createApiGatewayEvent(

--- a/src/test/integration/ipv-stub/ipv-user-identity.test.ts
+++ b/src/test/integration/ipv-stub/ipv-user-identity.test.ts
@@ -6,12 +6,17 @@ import { USER_IDENTITY } from "../../../main/ipv-stub/data/ipv-dummy-constants";
 import { handler } from "../../../main/ipv-stub/ipv-user-identity";
 import { createApiGatewayEvent } from "../util";
 
-const TOKEN = "SEGyn3duzJCo5GezC4XZQKJsMek8X749Foc5V3XpK4KHsA_9";
-
-beforeEach(setUpUserIdentity);
-afterEach(resetUserIdentityTable);
-
 describe("IPV User Identity", () => {
+  const TOKEN = "SEGyn3duzJCo5GezC4XZQKJsMek8X749Foc5V3XpK4KHsA_9";
+
+  beforeEach(async () => {
+    await setUpUserIdentity();
+  });
+
+  afterEach(async () => {
+    await resetUserIdentityTable();
+  });
+
   it("should return 200 for a get request", async () => {
     const response = await handler(
       createApiGatewayEvent("GET", null!, null!, {
@@ -34,8 +39,8 @@ describe("IPV User Identity", () => {
     );
     expect(response.statusCode).toBe(405);
   });
-});
 
-async function setUpUserIdentity(): Promise<void> {
-  await putUserIdentity(TOKEN, USER_IDENTITY);
-}
+  async function setUpUserIdentity(): Promise<void> {
+    await putUserIdentity(TOKEN, USER_IDENTITY);
+  }
+});


### PR DESCRIPTION
There are still intermittent integration tests. Make test setups better and no leaking to other tests.