### PR TITLE
ATO-1795: add support for returning oAuth errors from IPV stub

### DIFF
--- a/src/main/ipv-stub/ipv-authorize.ts
+++ b/src/main/ipv-stub/ipv-authorize.ts
@@ -113,7 +113,7 @@ async function post(
     throw new CodedError(500, `dynamoDb error: ${error}`);
   }
 
-  if (parsedBody.oAuthError) {
+  if (parsedBody["oAuth-error-yes"] === "yes") {
     url.searchParams.append("error", parsedBody.oAuthError);
     url.searchParams.append(
       "error_description",

--- a/src/main/ipv-stub/render-ipv-authorize.ts
+++ b/src/main/ipv-stub/render-ipv-authorize.ts
@@ -79,19 +79,24 @@ export default function renderIPVAuthorize(
   <h3 class="govuk-heading-s">Form:</h3>
   <p class="govuk-body">Use this form to configure the required IPV user identity response. On submit a POST request will be sent to /authorize and the IPV OAuth 2.0 flow will be initiated.</p>
 
-  <div class="govuk-form-group">
-  <label class="govuk-label" for="form-success">
-    oAuth Error
-  </label>
-  <select class="govuk-select" id="form-success" name="form-success">
-    <option selected="selected" value="none">None</option>
-    <option value="oAuthError">Error</option>
-  </select>
-</div>
   <form action="/authorize" method="post">
    <input type="hidden" name="authCode" value=${authCode}>
 
   <dl class="govuk-summary-list">
+
+<div class="govuk-summary-list__row" id="oAuth-error-checkbox">
+<dt class="govuk-summary-list__key">
+Return an oAuth error
+</dt>
+<dd class="govuk-summary-list__value" id="oAuthError">
+<div class="govuk-checkboxes__item">
+<input class="govuk-checkboxes__input" id="oAuth-error-yes" name="oAuth-error-yes" type="checkbox" value="yes">
+<label class="govuk-label govuk-checkboxes__label" for="oAuth-error-yes">
+  Yes
+</label>
+</div>
+</dd>
+</div>
 
   <div class="govuk-summary-list__row" id="sub-claim-row">
   <dt class="govuk-summary-list__key">
@@ -195,7 +200,7 @@ Trustmark claim (vtm)
         oAuth Error
     </dt>
     <dd class="govuk-summary-list__value" id="oAuthError">
-    <textarea class="govuk-textarea" rows="2" id="oAuthError" name="oAuthError" type="text"></textarea>
+    <textarea class="govuk-textarea" rows="2" id="oAuthErrorCode" name="oAuthError" type="text"></textarea>
     </dd>
       </div>
 
@@ -210,7 +215,7 @@ Trustmark claim (vtm)
     <button name="continue" value="continue" class="govuk-button">Continue</button>
   </form>`,
     `
-  const dropdown = document.getElementById("form-success")
+  const dropdown = document.getElementById("oAuth-error-yes")
   const oAuthErrorInput = document.getElementById("oAuthErrorRow")
   const oAuthErrorDesc = document.getElementById("oAuthErrorDescriptionRow")
   const claim_values= ["sub-claim-row",
@@ -228,18 +233,8 @@ Trustmark claim (vtm)
     oAuthErrorDesc.classList.add("hidden")
 
 
-  dropdown.addEventListener("change", () => {
-    const val = dropdown.value
-    if(val === "none"){
-      oAuthErrorInput.classList.add("hidden")
-      oAuthErrorDesc.classList.add("hidden")
-
-      claim_values.forEach(claimField => {
-        const claimElement = document.getElementById(claimField)
-        claimElement?.classList?.remove("hidden")
-      })
-
-    } else if (val === "oAuthError"){
+  dropdown.addEventListener("change", (event) => {
+     if (event.currentTarget.checked){
       claim_values.forEach(claimField => {
         const claimElement = document.getElementById(claimField)
         claimElement?.classList?.add("hidden")
@@ -247,6 +242,16 @@ Trustmark claim (vtm)
 
       oAuthErrorInput.classList.remove("hidden")
       oAuthErrorDesc.classList.remove("hidden")
+
+      document.getElementById("oAuthErrorCode").value = "";
+      document.getElementById("oAuthErrorDescription").value  = "";
+    } else {
+      oAuthErrorInput.classList.add("hidden")
+      oAuthErrorDesc.classList.add("hidden")
+      claim_values.forEach(claimField => {
+        const claimElement = document.getElementById(claimField)
+        claimElement?.classList?.remove("hidden")
+      })
     }
   })`
   );

--- a/src/main/ipv-stub/render-ipv-authorize.ts
+++ b/src/main/ipv-stub/render-ipv-authorize.ts
@@ -78,12 +78,22 @@ export default function renderIPVAuthorize(
   
   <h3 class="govuk-heading-s">Form:</h3>
   <p class="govuk-body">Use this form to configure the required IPV user identity response. On submit a POST request will be sent to /authorize and the IPV OAuth 2.0 flow will be initiated.</p>
+
+  <div class="govuk-form-group">
+  <label class="govuk-label" for="form-success">
+    oAuth Error
+  </label>
+  <select class="govuk-select" id="form-success" name="form-success">
+    <option selected="selected" value="none">None</option>
+    <option value="oAuthError">Error</option>
+  </select>
+</div>
   <form action="/authorize" method="post">
    <input type="hidden" name="authCode" value=${authCode}>
 
   <dl class="govuk-summary-list">
 
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row" id="sub-claim-row">
   <dt class="govuk-summary-list__key">
       Subject Claim (sub)
   </dt>
@@ -92,7 +102,7 @@ export default function renderIPVAuthorize(
   </dd>
 </div>
 
-<div class="govuk-summary-list__row">
+<div class="govuk-summary-list__row" id="vtr-claim-row">
 <dt class="govuk-summary-list__key">
 Vector of trust claim (vot)
 </dt>
@@ -101,7 +111,7 @@ Vector of trust claim (vot)
 </dd>
 </div>
 
-<div class="govuk-summary-list__row">
+<div class="govuk-summary-list__row" id="vtm-claim-row">
 <dt class="govuk-summary-list__key">
 Trustmark claim (vtm)
 </dt>
@@ -110,7 +120,7 @@ Trustmark claim (vtm)
 </dd>
 </div>
 
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row" id="identity-claim-row">
     <dt class="govuk-summary-list__key">
         CoreIdentity Claim
     </dt>
@@ -121,7 +131,7 @@ Trustmark claim (vtm)
 
   ${
     claimKeys.includes("https://vocab.account.gov.uk/v1/address")
-      ? `<div class="govuk-summary-list__row">
+      ? `<div class="govuk-summary-list__row" id="address-claim-row">
   <dt class="govuk-summary-list__key">
       Address Claim
   </dt>
@@ -134,7 +144,7 @@ Trustmark claim (vtm)
 
   ${
     claimKeys.includes("https://vocab.account.gov.uk/v1/passport")
-      ? `<div class="govuk-summary-list__row">
+      ? `<div class="govuk-summary-list__row" id="passport-claim-row">
       <dt class="govuk-summary-list__key">
           Passport Claim
       </dt>
@@ -147,7 +157,7 @@ Trustmark claim (vtm)
 
   ${
     claimKeys.includes("https://vocab.account.gov.uk/v1/drivingPermit")
-      ? ` <div class="govuk-summary-list__row">
+      ? ` <div class="govuk-summary-list__row" id="driving-permit-record-row">
       <dt class="govuk-summary-list__key">
           Driving Permit Claim
       </dt>
@@ -160,7 +170,7 @@ Trustmark claim (vtm)
   
   ${
     claimKeys.includes("https://vocab.account.gov.uk/v1/socialSecurityRecord")
-      ? ` <div class="govuk-summary-list__row">
+      ? ` <div class="govuk-summary-list__row" id="social-security-record-row">
       <dt class="govuk-summary-list__key">
           Social Security Record Claim
       </dt>
@@ -171,15 +181,73 @@ Trustmark claim (vtm)
       : ""
   }
  
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row" id="return-code-row">
     <dt class="govuk-summary-list__key">
         Return Code Claim
     </dt>
     <dd class="govuk-summary-list__value" id="user-info-return-code-claim-present">
     <textarea class="govuk-textarea" rows="8" id="return_code_claim" name="return_code_claim" type="text">${JSON.stringify(config.returnCode, null, 2)}</textarea>
     </dd>
+    </div>
+
+    <div class="govuk-summary-list__row" id="oAuthErrorRow">
+    <dt class="govuk-summary-list__key">
+        oAuth Error
+    </dt>
+    <dd class="govuk-summary-list__value" id="oAuthError">
+    <textarea class="govuk-textarea" rows="2" id="oAuthError" name="oAuthError" type="text"></textarea>
+    </dd>
+      </div>
+
+    <div class="govuk-summary-list__row" id="oAuthErrorDescriptionRow">
+    <dt class="govuk-summary-list__key">
+        oAuth Error Description
+    </dt>
+    <dd class="govuk-summary-list__value" id="oAuthErrorDescriptionId">
+    <textarea class="govuk-textarea" rows="2" id="oAuthErrorDescription" name="oAuthErrorDescription" type="text"></textarea>
+    </dd>
   </div>
     <button name="continue" value="continue" class="govuk-button">Continue</button>
-  </form>`
+  </form>`,
+    `
+  const dropdown = document.getElementById("form-success")
+  const oAuthErrorInput = document.getElementById("oAuthErrorRow")
+  const oAuthErrorDesc = document.getElementById("oAuthErrorDescriptionRow")
+  const claim_values= ["sub-claim-row",
+  "vtr-claim-row",
+  "vtm-claim-row", 
+  "identity-claim-row", 
+  "passport-claim-row", 
+  "address-claim-row",
+  "driving-permit-record-row",
+  "social-security-record-row",
+  "return-code-row"
+   ]
+
+    oAuthErrorInput.classList.add("hidden")
+    oAuthErrorDesc.classList.add("hidden")
+
+
+  dropdown.addEventListener("change", () => {
+    const val = dropdown.value
+    if(val === "none"){
+      oAuthErrorInput.classList.add("hidden")
+      oAuthErrorDesc.classList.add("hidden")
+
+      claim_values.forEach(claimField => {
+        const claimElement = document.getElementById(claimField)
+        claimElement?.classList?.remove("hidden")
+      })
+
+    } else if (val === "oAuthError"){
+      claim_values.forEach(claimField => {
+        const claimElement = document.getElementById(claimField)
+        claimElement?.classList?.add("hidden")
+      })
+
+      oAuthErrorInput.classList.remove("hidden")
+      oAuthErrorDesc.classList.remove("hidden")
+    }
+  })`
   );
 }

--- a/src/main/ipv-stub/render-ipv-authorize.ts
+++ b/src/main/ipv-stub/render-ipv-authorize.ts
@@ -26,7 +26,13 @@ export default function renderIPVAuthorize(
   return renderPage(
     "IPV Stub Form",
     `<h1 class="govuk-heading-l">IPV stub</h1>
-  <h3 class="govuk-heading-s">Decrypted JAR header:</h3>
+    <details class="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Decrypted JAR claims
+    </span>
+  </summary>
+  <h3 class="govuk-heading-s">Header:</h3>
   <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">
@@ -36,7 +42,7 @@ export default function renderIPVAuthorize(
   ${decodedHeader.alg}
   </dd>
   </dl>
-  <h3 class="govuk-heading-s">Decrypted JAR Claims:</h3>
+  <h3 class="govuk-heading-s">Claims:</h3>
   <dl class="govuk-summary-list">
   ${payloadWithoutClaims
     .map(
@@ -67,6 +73,8 @@ export default function renderIPVAuthorize(
     </dd>
   </div>
   </dl>
+  
+</details>
   
   <h3 class="govuk-heading-s">Form:</h3>
   <p class="govuk-body">Use this form to configure the required IPV user identity response. On submit a POST request will be sent to /authorize and the IPV OAuth 2.0 flow will be initiated.</p>

--- a/src/main/template.ts
+++ b/src/main/template.ts
@@ -1,6 +1,6 @@
 import { govukStyles } from "./style";
 
-export const renderPage = (title: string, mainContent: string) => {
+export const renderPage = (title: string, mainContent: string, script = "") => {
   return `<!DOCTYPE html>
 <html lang="en" class="govuk-template">
 
@@ -16,6 +16,10 @@ export const renderPage = (title: string, mainContent: string) => {
 <!--  <link rel="manifest" href="/assets/manifest.json">-->
 <style>
 ${govukStyles}
+
+.hidden {
+  display: none;
+}
 </style>
 </head>
 
@@ -83,6 +87,7 @@ ${govukStyles}
       </div>
     </div>
   </footer>
+  <script>${script}</script>
 </body>
 
 </html>`;

--- a/src/test/integration/ipv-stub/ipv-authorize.test.ts
+++ b/src/test/integration/ipv-stub/ipv-authorize.test.ts
@@ -47,6 +47,7 @@ describe("IPV Authorize", () => {
       createApiGatewayEvent(
         "POST",
         new URLSearchParams({
+          "oAuth-error-yes": "yes",
           oAuthError: "session_invalidated",
           oAuthErrorDescription: "access denied",
         }).toString(),

--- a/src/test/integration/ipv-stub/ipv-authorize.test.ts
+++ b/src/test/integration/ipv-stub/ipv-authorize.test.ts
@@ -42,6 +42,29 @@ describe("IPV Authorize", () => {
     expect(state).toBe(STATE);
   });
 
+  it("should return a 302 with the specified oauth error and not update dynamo", async () => {
+    const response = await handler(
+      createApiGatewayEvent(
+        "POST",
+        new URLSearchParams({
+          oAuthError: "session_invalidated",
+          oAuthErrorDescription: "access denied",
+        }).toString(),
+        {},
+        {}
+      ),
+      {} as Context,
+      () => {}
+    );
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.Location).toBe(
+      `https://oidc.local.account.gov.uk/ipv-callback?${new URLSearchParams({
+        error: "session_invalidated",
+        error_description: "access denied",
+      }).toString()}`
+    );
+  });
+
   it("should return 302 for valid POST request and update Dynamo", async () => {
     const response = await handler(
       createApiGatewayEvent("POST", generateFormBody(), {}, {}),


### PR DESCRIPTION
## What:
- Adds the ability to return oAuth errors from the IPV stub 
- Will be used to test the session_invalidated handling as part of this ticket
- Adds a small change to the way the page is rendered under the BAU commit 
## How to review:
- Deployed to dev - have a play with the UI 
- Selected oAuth error from the drop down and entered an error and error_description - was redirected with the values
- Input an oAuth error description and see this is propagated back to Orch