### PR TITLE
ATO 1581/setup auth stub hosted zone

### DIFF
--- a/auth-stub-template.yml
+++ b/auth-stub-template.yml
@@ -28,8 +28,10 @@ Conditions:
 Mappings:
   EnvironmentConfiguration:
     dev:
+      authStubDomainName: authstub.oidc.authdev3.dev.account.gov.uk
       orchToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHzG8IFx1jE1+Ul44jQk96efPknCXVxWS4PqLrKfR/31UQovFQLfyxA46uiMOvr7+0hRwFX1fQhagsIK+dfB5PA==
     build:
+      authStubDomainName: authstub.oidc.build.account.gov.uk
       orchToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPrCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==
 
 Globals:
@@ -317,3 +319,25 @@ Resources:
       PendingWindowInDays: 30
       KeyUsage: ENCRYPT_DECRYPT
       KeySpec: RSA_2048
+
+  PublicHostedZone:
+    Type: AWS::Route53::HostedZone
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          authStubDomainName,
+        ]
+
+Outputs:
+  AuthHostedZoneId:
+    Value: !GetAtt PublicHostedZone.Id
+    Export:
+      Name: AuthHostedZoneId
+  AuthApiGatewayId:
+    Value: !Ref ApiGateway
+    Export:
+      Name: AuthApiGatewayId


### PR DESCRIPTION
Setting up to create a custom domain for the authstub

 - created hosted zone with subdomain and export ids of hosted zone and api gateway for manual template.