### PR TITLE
ATO 1829/create auth stub custom domain name

### DIFF
--- a/infrastructure/manual-stacks/auth/dns-zones/README.md
+++ b/infrastructure/manual-stacks/auth/dns-zones/README.md
@@ -1,0 +1,24 @@
+# Manual stacks - DNS
+## Intro
+
+The SAM template creates a DNS record and certificate for `authstub.oidc.<environment>.account.gov.uk` (or `authstub.oidc.account.gov.uk` if environment is `production`).
+Note that the `dev` environment gets mapped to `authdev3`. 
+
+This Stack is deployed manually once per environment as part of the DNS set up process. 
+
+
+## Deployment
+
+Login into AWS with SSO on the browser. Choose an account, and select `Command line or programmatic access`. In your
+terminal, run `aws configure sso` and enter the start URL and region from AWS on your browser. This will create a
+profile that you can set as an environment variable, by running `export AWS_PROFILE=<profile>`. Then run `aws sso login`
+to login into that profile to use.
+
+**_NOTE:_** Make sure the link-hosted-zone stack is deployed otherwwise this stack will fail to create the certificate.
+
+After this you can then run the below, replacing `<environment>`with one
+of `dev`, `build`, `staging`, `integration`, `production`:
+
+```shell
+./deploy_dns_zone.sh <environment>
+```

--- a/infrastructure/manual-stacks/auth/dns-zones/deploy_dns_zone.sh
+++ b/infrastructure/manual-stacks/auth/dns-zones/deploy_dns_zone.sh
@@ -1,0 +1,8 @@
+ENVIRONMENT=${1}
+
+sam deploy --stack-name $ENVIRONMENT-orch-auth-stub-dns-zone \
+  --template-file template.yaml \
+  --parameter-overrides Environment=$ENVIRONMENT \
+  --tags \
+    Source=govuk-one-login/orch-stubs \
+    Owner=di-orchestration@digital.cabinet-office.gov.uk

--- a/infrastructure/manual-stacks/auth/dns-zones/template.yaml
+++ b/infrastructure/manual-stacks/auth/dns-zones/template.yaml
@@ -1,0 +1,69 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >-
+  The Auth DNS Hosted Zones for the Orchestration Stubs.
+Parameters:
+  Environment:
+    Description: The name of the environment to deploy to
+    Type: String
+    AllowedValues:
+      - dev
+      - build
+      - staging
+      - integration
+      - production
+
+Mappings:
+  EnvironmentConfiguration:
+    dev:
+      authStubDomainName: authstub.oidc.authdev3.dev.account.gov.uk
+    build:
+      authStubDomainName: authstub.oidc.build.account.gov.uk
+    staging:
+      authStubDomainName: authstub.oidc.staging.account.gov.uk
+    integration:
+      authStubDomainName: authstub.oidc.integration.account.gov.uk
+    production:
+      authStubDomainName: authstub.oidc.account.gov.uk
+
+Resources:
+  AuthStubCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName:  
+        !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubDomainName ]
+      DomainValidationOptions:
+        - DomainName: 
+            !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubDomainName ]
+          HostedZoneId: !ImportValue AuthHostedZoneId
+      ValidationMethod: DNS
+      CertificateTransparencyLoggingPreference: ENABLED
+
+  AuthStubApiDomain:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      DomainName: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubDomainName ]
+      SecurityPolicy: TLS_1_2
+      RegionalCertificateArn: !Ref AuthStubCertificate
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+
+  AuthStubApiMapping:
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      DomainName: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubDomainName ]
+      RestApiId: !ImportValue AuthApiGatewayId
+      Stage: Live
+    DependsOn:
+      - AuthStubApiDomain
+
+  AuthStubDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Type: A
+      Name: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubDomainName ]
+      HostedZoneId: !ImportValue AuthHostedZoneId
+      AliasTarget:
+        DNSName: !GetAtt AuthStubApiDomain.RegionalDomainName
+        HostedZoneId: !GetAtt AuthStubApiDomain.RegionalHostedZoneId


### PR DESCRIPTION
### Context

Create custom domain for auth stub

### Changes

Create stack in orch account for custom domain resources. The hosted zone and linking between auth and orch for the subdomain creation has been done first.

Tested in dev connected to authdev3