### PR TITLE
ATO-1830 move auth stub domain to authdev3

### DIFF
--- a/auth-stub-template.yml
+++ b/auth-stub-template.yml
@@ -11,7 +11,9 @@ Parameters:
   Environment:
     Type: String
     Description: The name of the environment to deploy to
-    Default: none
+    AllowedValues:
+      - dev
+      - build
   CodeSigningConfigArn:
     Type: String
     Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline

--- a/auth-stub-template.yml
+++ b/auth-stub-template.yml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: Authentication, IPV and SPOT stubs
 
@@ -31,9 +31,11 @@ Mappings:
   EnvironmentConfiguration:
     dev:
       authStubDomainName: authstub.oidc.authdev3.dev.account.gov.uk
+      authDomain: authdev3.dev.account.gov.uk
       orchToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHzG8IFx1jE1+Ul44jQk96efPknCXVxWS4PqLrKfR/31UQovFQLfyxA46uiMOvr7+0hRwFX1fQhagsIK+dfB5PA==
     build:
       authStubDomainName: authstub.oidc.build.account.gov.uk
+      authDomain: build.account.gov.uk
       orchToAuthSigningPublicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPrCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==
 
 Globals:
@@ -118,7 +120,6 @@ Resources:
       StageName: Live
       AlwaysDeploy: true
 
-
   AuthAuthorizeLambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -132,7 +133,14 @@ Resources:
           ENVIRONMENT: !Sub ${Environment}
           ENCRYPTION_KEY_ID: "{{resolve:secretsmanager:/orch-stubs/authentication-encryption-key-id:SecretString}}"
           ORCH_TO_AUTH_CLIENT_ID: "orchestrationAuth"
-          ORCH_TO_AUTH_AUDIENCE: "https://signin.sandpit.account.gov.uk/"
+          ORCH_TO_AUTH_AUDIENCE: !Sub
+            - "https://signin.${authDomain}/"
+            - authDomain:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  authDomain,
+                ]
           # These will always be over-written when running locally in parameters.json
           LOCALSTACK_ENDPOINT: !If [IsLocalEnv, "", !Ref AWS::NoValue]
           DUMMY_ENCRYPTION_PUBLIC_KEY: !If [IsLocalEnv, "", !Ref AWS::NoValue]
@@ -174,11 +182,12 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub ${Environment}
-          ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY: !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                orchToAuthSigningPublicKey,
-              ]
+          ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              orchToAuthSigningPublicKey,
+            ]
       Events:
         Get:
           Type: Api
@@ -317,7 +326,7 @@ Resources:
               - dynamodb:UpdateItem
               - dynamodb:PutItem
             Resource: !GetAtt UserProfileTable.Arn
-  
+
   AuthEncryptionKeyAlias:
     Type: "AWS::KMS::Alias"
     Properties:

--- a/infrastructure/manual-stacks/README.md
+++ b/infrastructure/manual-stacks/README.md
@@ -1,0 +1,11 @@
+# Ordering of manual stacks deployment 
+
+The manual stacks directory contains two directories one for the IPV stub and the other for the Auth stub. Each one contains the same two templates: 
+- link hosted zone
+- dns zone
+
+These manual stacks need to be deployed in a certain order alongside the application stack as they depend on parameters for each other.
+
+1) Firstly we need to deploy the main stub application stack with a Hosted Zone pointing to the desired domain name. 
+2) Once this has deployed we can deploy the link hosted zone stack by following the instructions in the README. 
+3) Finally we can deploy the dns zones stack by following the instructions in the README.

--- a/infrastructure/manual-stacks/auth/dns-zones/README.md
+++ b/infrastructure/manual-stacks/auth/dns-zones/README.md
@@ -1,11 +1,11 @@
 # Manual stacks - DNS
+
 ## Intro
 
-The SAM template creates a DNS record and certificate for `authstub.oidc.<environment>.account.gov.uk` (or `authstub.oidc.account.gov.uk` if environment is `production`).
-Note that the `dev` environment gets mapped to `authdev3`. 
+The SAM template creates a DNS record and certificate for `authstub.oidc.<environment>.account.gov.uk`.
+Note that the `dev` environment gets mapped to `authdev3`.
 
-This Stack is deployed manually once per environment as part of the DNS set up process. 
-
+This Stack is deployed manually once per environment as part of the DNS set up process.
 
 ## Deployment
 
@@ -17,7 +17,7 @@ to login into that profile to use.
 **_NOTE:_** Make sure the link-hosted-zone stack is deployed otherwwise this stack will fail to create the certificate.
 
 After this you can then run the below, replacing `<environment>`with one
-of `dev`, `build`, `staging`, `integration`, `production`:
+of `dev`, `build`:
 
 ```shell
 ./deploy_dns_zone.sh <environment>

--- a/infrastructure/manual-stacks/auth/dns-zones/deploy_dns_zone.sh
+++ b/infrastructure/manual-stacks/auth/dns-zones/deploy_dns_zone.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ENVIRONMENT=${1}
 
 sam deploy --stack-name $ENVIRONMENT-orch-auth-stub-dns-zone \

--- a/infrastructure/manual-stacks/auth/dns-zones/template.yaml
+++ b/infrastructure/manual-stacks/auth/dns-zones/template.yaml
@@ -9,9 +9,6 @@ Parameters:
     AllowedValues:
       - dev
       - build
-      - staging
-      - integration
-      - production
 
 Mappings:
   EnvironmentConfiguration:
@@ -19,12 +16,6 @@ Mappings:
       authStubDomainName: authstub.oidc.authdev3.dev.account.gov.uk
     build:
       authStubDomainName: authstub.oidc.build.account.gov.uk
-    staging:
-      authStubDomainName: authstub.oidc.staging.account.gov.uk
-    integration:
-      authStubDomainName: authstub.oidc.integration.account.gov.uk
-    production:
-      authStubDomainName: authstub.oidc.account.gov.uk
 
 Resources:
   AuthStubCertificate:

--- a/infrastructure/manual-stacks/auth/link-hosted-zone/README.md
+++ b/infrastructure/manual-stacks/auth/link-hosted-zone/README.md
@@ -9,9 +9,6 @@ into this template to deploy into the root domain account.
 
 ### Root Domain accounts
 
- - Production  = `gds-di-production`
- - Integration = `gds-di-development`
- - Staging     = `di-auth-staging`
  - Build       = `gds-di-development`
  - Dev         = `di-auth-development`
 
@@ -25,7 +22,7 @@ to login into that profile to use.
 **_NOTE:_** Make sure the hosted zone is created in the orchestration account first and then the NS values copied over to the right root account
 
 After this you can then run the below, replacing `<environment>`with one
-of `dev`, `build`, `staging`, `integration`, `production`:
+of `dev`, `build`:
 
 ```shell
 ./deploy_link_hosted_zone.sh <environment>

--- a/infrastructure/manual-stacks/auth/link-hosted-zone/deploy_link_hosted_zone.sh
+++ b/infrastructure/manual-stacks/auth/link-hosted-zone/deploy_link_hosted_zone.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ENVIRONMENT=${1}
 
 sam deploy --stack-name $ENVIRONMENT-orch-auth-stub-link-hosted-zone \

--- a/infrastructure/manual-stacks/auth/link-hosted-zone/template.yaml
+++ b/infrastructure/manual-stacks/auth/link-hosted-zone/template.yaml
@@ -15,28 +15,45 @@ Mappings:
     dev:
       oidcHostedZoneId: Z092159727B0APSLCJ6S7
       authStubDomainName: authstub.oidc.authdev3.dev.account.gov.uk
-      authStubResourceRecords: [
-            ns-652.awsdns-17.net,
-            ns-246.awsdns-30.com,
-            ns-1046.awsdns-02.org,
-            ns-1899.awsdns-45.co.uk
-          ]
+      authStubResourceRecords:
+        [
+          ns-278.awsdns-34.com,
+          ns-1784.awsdns-31.co.uk,
+          ns-975.awsdns-57.net,
+          ns-1086.awsdns-07.org,
+        ]
     build:
       oidcHostedZoneId: Z062899930H8VN1UJ9CDX
       authStubDomainName: authstub.oidc.build.account.gov.uk
-      authStubResourceRecords: [
-            ns-120.awsdns-15.com,
-            ns-575.awsdns-07.net,
-            ns-1961.awsdns-53.co.uk,
-            ns-1311.awsdns-35.org
-          ]
+      authStubResourceRecords:
+        [
+          ns-120.awsdns-15.com,
+          ns-575.awsdns-07.net,
+          ns-1961.awsdns-53.co.uk,
+          ns-1311.awsdns-35.org,
+        ]
 
 Resources:
   AuthStubNSRecord:
     Type: AWS::Route53::RecordSet
     Properties:
       Type: NS
-      Name: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubDomainName ]
-      HostedZoneId: !FindInMap [ EnvironmentConfiguration, !Ref Environment, oidcHostedZoneId ]
-      ResourceRecords: !FindInMap [ EnvironmentConfiguration, !Ref Environment, authStubResourceRecords ]
+      Name:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          authStubDomainName,
+        ]
+      HostedZoneId:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          oidcHostedZoneId,
+        ]
+      ResourceRecords:
+        !FindInMap [
+          EnvironmentConfiguration,
+          !Ref Environment,
+          authStubResourceRecords,
+        ]
       TTL: 172800

--- a/infrastructure/manual-stacks/auth/link-hosted-zone/template.yaml
+++ b/infrastructure/manual-stacks/auth/link-hosted-zone/template.yaml
@@ -9,9 +9,6 @@ Parameters:
     AllowedValues:
       - dev
       - build
-      - staging
-      - integration
-      - production
 
 Mappings:
   EnvironmentConfiguration:
@@ -33,15 +30,6 @@ Mappings:
             ns-1961.awsdns-53.co.uk,
             ns-1311.awsdns-35.org
           ]
-    staging:
-      oidcHostedZoneId: Z013545810R9Q9A5U2JW5
-      authStubDomainName: authstub.oidc.staging.account.gov.uk
-    integration:
-      oidcHostedZoneId: Z015965529V3Z8WL9WJMF
-      authStubDomainName: authstub.oidc.integration.account.gov.uk
-    production:
-      oidcHostedZoneId: Z06269462RT1OC3QFCZZE
-      authStubDomainName: authstub.oidc.account.gov.uk
 
 Resources:
   AuthStubNSRecord:


### PR DESCRIPTION
Repoints the auth stub to authdev3 as this was pointing to a different domain as part of work to run through an end-to-end journey