### PR TITLE
BAU: Improve dependency management

### DIFF
--- a/.github/workflows/deploy-stubs.yml
+++ b/.github/workflows/deploy-stubs.yml
@@ -48,7 +48,7 @@ jobs:
           key: orch-sam
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run build
         run: npm run build

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: "20.x"
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run lint
         run: npm run check:lint
       - name: Run prettier
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: "20.x"
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Configure Docker for ARM

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/auth-stub-template.yml
+++ b/auth-stub-template.yml
@@ -161,6 +161,7 @@ Resources:
         Minify: true
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   AuthTokenLambda:
     Type: AWS::Serverless::Function
@@ -199,6 +200,7 @@ Resources:
         Minify: true
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   AuthUserInfoLambda:
     Type: AWS::Serverless::Function
@@ -236,6 +238,7 @@ Resources:
         Minify: true
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   AuthCodeTableReadAccessPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/ipv-stub-template.yml
+++ b/ipv-stub-template.yml
@@ -130,6 +130,7 @@ Resources:
           - "@aws-sdk/lib-dynamodb"
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   IPVAuthorizeLambdaLogGroup:
     Type: AWS::Logs::LogGroup
@@ -189,6 +190,7 @@ Resources:
           - "@aws-sdk/lib-dynamodb"
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   IPVTokenLambdaLogGroup:
     Type: AWS::Logs::LogGroup
@@ -235,6 +237,7 @@ Resources:
           - "@aws-sdk/lib-dynamodb"
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   IPVJwksLambda:
     Type: AWS::Serverless::Function
@@ -263,6 +266,7 @@ Resources:
         Minify: true
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   IPVUserIdentityLambdaLogGroup:
     Type: AWS::Logs::LogGroup

--- a/spot-stub-template.yml
+++ b/spot-stub-template.yml
@@ -82,6 +82,7 @@ Resources:
         Minify: true
         Sourcemap: true
         Target: node20
+        UseNpmCi: True
 
   SpotResponseQueueWritePolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
Some small changes to the way we pull in dependencies, namely:
- Use `npm ci` not `npm install` in our sam build and GHAs 
- Adds a `.npmrc` with `ignore-scripts=true` to ensure lifecycle scripts are ignored