### PR TITLE
ATO-2523: add account_data_api_access_token to auth stub and return hard coded value

### DIFF
--- a/src/main/auth-stub/auth-userinfo.ts
+++ b/src/main/auth-stub/auth-userinfo.ts
@@ -122,5 +122,6 @@ const populateUserInfo = async (
     verified_mfa_method_type: "",
     uplift_required: "",
     achieved_credential_strength: "MEDIUM_LEVEL",
+    account_data_api_access_token: "account-data-api-access-token",
   };
 };

--- a/src/main/auth-stub/helpers/claims-config.ts
+++ b/src/main/auth-stub/helpers/claims-config.ts
@@ -34,6 +34,7 @@ export interface Claims {
   scope: string;
   requested_level_of_confidence?: string;
   requested_credential_strength: string;
+  account_data_api_access_token?: string;
 }
 
 export const requiredClaimsKeys = [

--- a/src/main/auth-stub/interfaces/user-info-claim-interface.ts
+++ b/src/main/auth-stub/interfaces/user-info-claim-interface.ts
@@ -14,4 +14,5 @@ export interface UserInfoClaims {
   verified_mfa_method_type: string;
   uplift_required: string;
   achieved_credential_strength: string;
+  account_data_api_access_token?: string;
 }


### PR DESCRIPTION
We want to return `account_data_api_access_token`. Currently most of our userinfo is hard coded values so that's what we will do for now but have raised a ticket to update the auth stub to at least return what is requested (even if that is still hard coded values).