### PR TITLE
ATO-2524: Reduce flakiness of integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:coverage": "vitest run --coverage",
     "test:localstack:integration": "npm run localstack:up && (vitest run --config=./vitest.integration.config.ts && e=0) || e=1 && npm run localstack:down && exit $e",
     "test:integration": "vitest run --config=./vitest.integration.config.ts",
-    "test:ci": "tsc --noEmit && npm run localstack:up && (vitest run --passWithNoTests --config=./vitest.ci.config.ts && e=0) || e=1 && npm run localstack:down && exit $e",
+    "test:ci": "tsc --noEmit && npm run localstack:up && (npm run test:unit && e=0) && (npm run test:integration && e=0) || e=1 && npm run localstack:down && exit $e",
     "localstack:up": "docker compose -f docker-compose.local.yml up -d",
     "localstack:down": "docker compose -f docker-compose.local.yml down",
     "prepare": "husky",

--- a/src/test/integration/auth-stub/auth-authorize.test.ts
+++ b/src/test/integration/auth-stub/auth-authorize.test.ts
@@ -5,26 +5,32 @@ import { mockEnvVariableSetup } from "./helpers/test-setup.ts";
 import * as decryptionHelper from "../../../main/auth-stub/helpers/decryption-helper.ts";
 import {
   addUserProfile,
-  resetAuthCodeStore,
-  resetUserProfile,
+  deleteAuthCode,
+  deleteUserProfile,
 } from "./helpers/dynamo-helper.ts";
 import { createUserPofile } from "../../../main/auth-stub/test-helper/mock-token-data-helper.ts";
 import { SignJWT, importPKCS8 } from "jose";
 import localParams from "../../../../parameters.json";
 
+vi.mock("node:crypto", () => {
+  return { getRandomValues: vi.fn(() => Buffer.from("test")) };
+});
+const AUTH_CODE = Buffer.from("test").toString("base64url");
+
 describe("Auth Authorize", () => {
   const EMAIL = "dummy.email@mail.com";
+  const USER_PROFILE = createUserPofile(EMAIL);
 
   beforeEach(async () => {
     mockEnvVariableSetup();
     const jwt = await createJwt(createMockClaims());
     vi.spyOn(decryptionHelper, "decrypt").mockResolvedValue(jwt);
-    await addUserProfile(createUserPofile(EMAIL));
+    await addUserProfile(USER_PROFILE);
   });
 
   afterEach(async () => {
-    await resetAuthCodeStore();
-    await resetUserProfile();
+    await deleteAuthCode(AUTH_CODE);
+    await deleteUserProfile(USER_PROFILE);
     vi.clearAllMocks();
   });
 

--- a/src/test/integration/auth-stub/auth-token.test.ts
+++ b/src/test/integration/auth-stub/auth-token.test.ts
@@ -2,10 +2,10 @@ import { createApiGatewayEvent } from "../util.ts";
 import { handler } from "../../../main/auth-stub/auth-token.ts";
 import {
   addAuthCodeStore,
+  deleteAccessToken,
+  deleteAuthCode,
   getAccessTokenStore,
   getAuthCodeStore,
-  resetAccessTokenStore,
-  resetAuthCodeStore,
 } from "./helpers/dynamo-helper.ts";
 import {
   createAuthCodeStoreInput,
@@ -22,6 +22,15 @@ interface AuthTokenResponse {
   access_token: string;
   token_type: string;
 }
+const ACCESS_TOKEN = "dGVzdC1hY2Nlc3MtdG9rZW4";
+vi.mock("jose", async () => {
+  return {
+    ...(await vi.importActual("jose")),
+    base64url: {
+      encode: vi.fn(() => ACCESS_TOKEN),
+    },
+  };
+});
 
 describe("Auth Token", () => {
   const AUTH_CODE = "12345";
@@ -32,8 +41,8 @@ describe("Auth Token", () => {
   });
 
   afterEach(async () => {
-    await resetAccessTokenStore();
-    await resetAuthCodeStore();
+    await deleteAccessToken(ACCESS_TOKEN);
+    await deleteAuthCode(AUTH_CODE);
     vi.clearAllMocks();
   });
 

--- a/src/test/integration/auth-stub/auth-userinfo.test.ts
+++ b/src/test/integration/auth-stub/auth-userinfo.test.ts
@@ -2,9 +2,9 @@ import { createApiGatewayEvent } from "../util.ts";
 import { handler } from "../../../main/auth-stub/auth-userinfo.ts";
 import {
   addUserProfile,
+  deleteAccessToken,
+  deleteUserProfile,
   getAccessTokenStore,
-  resetAccessTokenStore,
-  resetUserProfile,
 } from "./helpers/dynamo-helper.ts";
 import {
   addAccessTokenStore,
@@ -22,7 +22,7 @@ import { UserInfoClaims } from "src/main/auth-stub/interfaces/user-info-claim-in
 describe("Auth User Info", () => {
   const EMAIL = "dummy_user_info@mail.com";
   const SUBJECT_ID = "authUserInfoSubjectId";
-  const ACCESS_TOKEN = "12345";
+  const ACCESS_TOKEN = "123456";
 
   let userProfileMock: UserProfile;
 
@@ -33,8 +33,8 @@ describe("Auth User Info", () => {
   });
 
   afterEach(async () => {
-    await resetAccessTokenStore();
-    await resetUserProfile();
+    await deleteAccessToken(ACCESS_TOKEN);
+    await deleteUserProfile(userProfileMock);
   });
 
   it("should return 200 for valid GET request and update Dynamo", async () => {
@@ -108,9 +108,9 @@ describe("Auth User Info", () => {
   });
 
   it("should return a 401 error when access token has been used", async () => {
-    await resetAccessTokenStore();
+    const USED_ACCESS_TOKEN = "888888";
     await setUpCustomAccessToken({
-      accessToken: ACCESS_TOKEN,
+      accessToken: USED_ACCESS_TOKEN,
       hasBeenUsed: true,
     });
 
@@ -121,7 +121,7 @@ describe("Auth User Info", () => {
         {},
         {
           "Content-Type": "x-www-form-urlencoded",
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
+          Authorization: `Bearer ${USED_ACCESS_TOKEN}`,
         }
       ),
       null!,
@@ -132,12 +132,14 @@ describe("Auth User Info", () => {
     expect(response.multiValueHeaders["WWW-Authenticate"]).toStrictEqual([
       `Bearer error="invalid_token", error_description="Error: Invalid bearer token"`,
     ]);
+
+    await deleteAccessToken(USED_ACCESS_TOKEN);
   });
 
   it("should return a 401 error when access token has expired", async () => {
-    await resetAccessTokenStore();
+    const EXPIRED_ACCESS_TOKEN = "999999";
     await setUpCustomAccessToken({
-      accessToken: ACCESS_TOKEN,
+      accessToken: EXPIRED_ACCESS_TOKEN,
       ttl: Math.floor(Date.now() / 1000) - 180,
     });
 
@@ -148,7 +150,7 @@ describe("Auth User Info", () => {
         {},
         {
           "Content-Type": "x-www-form-urlencoded",
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
+          Authorization: `Bearer ${EXPIRED_ACCESS_TOKEN}`,
         }
       ),
       null!,
@@ -159,11 +161,12 @@ describe("Auth User Info", () => {
     expect(response.multiValueHeaders["WWW-Authenticate"]).toStrictEqual([
       `Bearer error="invalid_token", error_description="Error: Invalid bearer token"`,
     ]);
+
+    await deleteAccessToken(EXPIRED_ACCESS_TOKEN);
   });
 
   it("should return a 401 error when access token dynamo errors", async () => {
-    await resetAccessTokenStore();
-
+    const INVALID_ACCESS_TOKEN = "invalid-access-token";
     const response = await handler(
       createApiGatewayEvent(
         "GET",
@@ -171,7 +174,7 @@ describe("Auth User Info", () => {
         {},
         {
           "Content-Type": "x-www-form-urlencoded",
-          Authorization: `Bearer ${ACCESS_TOKEN}`,
+          Authorization: `Bearer ${INVALID_ACCESS_TOKEN}`,
         }
       ),
       null!,

--- a/src/test/integration/auth-stub/helpers/dynamo-helper.ts
+++ b/src/test/integration/auth-stub/helpers/dynamo-helper.ts
@@ -17,60 +17,6 @@ const authCodeTableName = `${process.env.ENVIRONMENT ?? "local"}-AuthStub-AuthCo
 const accessTokenTableName = `${process.env.ENVIRONMENT ?? "local"}-AuthStub-AccessToken`;
 const userProfileTableName = `${process.env.ENVIRONMENT ?? "local"}-AuthStub-UserProfile`;
 
-export async function resetAuthCodeStore() {
-  const result = await dynamo.scan({
-    TableName: authCodeTableName,
-    ConsistentRead: true,
-  });
-
-  if (result.Items) {
-    for (const item of result.Items) {
-      await dynamo.delete({
-        TableName: authCodeTableName,
-        Key: {
-          authCode: item.authCode,
-        },
-      });
-    }
-  }
-}
-
-export async function resetAccessTokenStore() {
-  const result = await dynamo.scan({
-    TableName: accessTokenTableName,
-    ConsistentRead: true,
-  });
-
-  if (result.Items) {
-    for (const item of result.Items) {
-      await dynamo.delete({
-        TableName: accessTokenTableName,
-        Key: {
-          accessToken: item.accessToken,
-        },
-      });
-    }
-  }
-}
-
-export async function resetUserProfile() {
-  const result = await dynamo.scan({
-    TableName: userProfileTableName,
-    ConsistentRead: true,
-  });
-
-  if (result.Items) {
-    for (const item of result.Items) {
-      await dynamo.delete({
-        TableName: userProfileTableName,
-        Key: {
-          email: item.email,
-        },
-      });
-    }
-  }
-}
-
 export async function getAuthCodeStore(
   authCode: string
 ): Promise<AuthCodeStore> {
@@ -133,6 +79,30 @@ export const addUserProfile = async (userProfile: UserProfile) => {
   });
 };
 
+export async function deleteAuthCode(authCode: string) {
+  await dynamo.delete({
+    TableName: authCodeTableName,
+    Key: {
+      authCode,
+    },
+  });
+}
+export async function deleteAccessToken(accessToken: string) {
+  await dynamo.delete({
+    TableName: accessTokenTableName,
+    Key: {
+      accessToken,
+    },
+  });
+}
+export async function deleteUserProfile(userProfile: UserProfile) {
+  await dynamo.delete({
+    TableName: userProfileTableName,
+    Key: {
+      email: userProfile.email,
+    },
+  });
+}
 function oneHourFromNow() {
   return Math.floor(Date.now() / 1000) + 3600;
 }

--- a/src/test/integration/setup.ts
+++ b/src/test/integration/setup.ts
@@ -5,10 +5,15 @@ const waitForLocalStack = async () => {
 
   do {
     try {
-      const res = await fetch("http://127.0.0.1:4566/_localstack/health");
+      const res = await fetch("http://127.0.0.1:4566/_localstack/init/ready");
 
       if (res.ok && res.status === 200) {
-        break;
+        const json = await res.json();
+        if (json.completed === true) {
+          break;
+        } else {
+          console.log(`Still creating tables (attempt ${polls}/20)`);
+        }
       }
     } catch (err) {
       console.error((err as Error).message);


### PR DESCRIPTION
The auth stub test files were removing all data in the DynamoDB tables at the end of each test. Since the auth stub test files shared the same tables, and there are 3 auth stub test files that run in parallel, this meant that one test could remove the data that another test setup, causing it to fail intermittently. 

I've updated the auth stub tests to use specific access tokens/auth codes/user profiles, so we can remove the data associated with that test file instead of interfering with other tests

I've also updated the setup file to wait for the `init-infra.sh` script to finish instead of just waiting for localstack to be up and running.